### PR TITLE
Update Geotools version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <url>http://geomati.co</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <geotools.version>8-SNAPSHOT</geotools.version>
+    <geotools.version>8.0</geotools.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Version 8-SNAPSHOT became final version 8.0 (this snapshot doesn't exist into the maven repo).
Tested with newer geotools versions: 
version <=11.0 --> Tests Ok.
version >=12.0 --> Tests fail.
